### PR TITLE
delete_logi_options_and_rancher

### DIFF
--- a/dotfiles-init/dot_config/brewfile/src.Brewfile
+++ b/dotfiles-init/dot_config/brewfile/src.Brewfile
@@ -64,9 +64,7 @@ cask 1password
 cask alfred
 cask apparency
 cask iterm2
-cask logitech-options
 cask munkiadmin
-cask rancher
 cask suspicious-package
 cask utm
 cask visual-studio-code


### PR DESCRIPTION
deleting logitech options and rancher to prevent them from being installed.